### PR TITLE
Change macro names to 'MODULES_*'

### DIFF
--- a/mbed-hal-st-stm32f401re/target_config.h
+++ b/mbed-hal-st-stm32f401re/target_config.h
@@ -21,8 +21,8 @@
 #define MINAR_PLATFORM_TIME_BASE  2000                   // ticks per second
 #define MINAR_PLATFORM_MINIMUM_SLEEP 2                   // in ticks
 
-#define MODULE_SIZE_SPI         4
-#define MODULE_SIZE_SERIAL      3
+#define MODULES_SIZE_SPI         4
+#define MODULES_SIZE_SERIAL      3
 
 // Transaction queue size for each peripheral
 #define TRANSACTION_QUEUE_SIZE_SPI   16


### PR DESCRIPTION
in order to align with 'mbed-drivers' usage of this type of macros.